### PR TITLE
Fix ProducerRecord to ConsumerRecord, add overload for serializer/deserializer

### DIFF
--- a/assurance/src/main/java/com/obsidiandynamics/jackdaw/MockKafka.java
+++ b/assurance/src/main/java/com/obsidiandynamics/jackdaw/MockKafka.java
@@ -16,6 +16,7 @@ import com.obsidiandynamics.func.*;
 import com.obsidiandynamics.props.*;
 import com.obsidiandynamics.yconf.*;
 import com.obsidiandynamics.zerolog.*;
+import org.apache.kafka.common.record.TimestampType;
 
 @Y
 public final class MockKafka<K, V> implements Kafka<K, V> {
@@ -142,8 +143,11 @@ public final class MockKafka<K, V> implements Kafka<K, V> {
       throw new InvalidPartitionException(m);
     }
     
-    final ConsumerRecord<K, V> cr = 
-        new ConsumerRecord<>(r.topic(), partition, offset, r.key(), r.value());
+    final ConsumerRecord<K, V> cr =
+        new ConsumerRecord<>(r.topic(), partition, offset,
+                ConsumerRecord.NO_TIMESTAMP, TimestampType.NO_TIMESTAMP_TYPE,
+                ConsumerRecord.NO_TIMESTAMP, ConsumerRecord.NULL_CHECKSUM, ConsumerRecord.NULL_CHECKSUM,
+                r.key(), r.value(), r.headers());
     
     final TopicPartition part = new TopicPartition(r.topic(), partition);
     synchronized (lock) {

--- a/src/main/java/com/obsidiandynamics/jackdaw/Kafka.java
+++ b/src/main/java/com/obsidiandynamics/jackdaw/Kafka.java
@@ -7,6 +7,8 @@ import org.apache.kafka.clients.consumer.*;
 import org.apache.kafka.clients.producer.*;
 
 import com.obsidiandynamics.func.*;
+import org.apache.kafka.common.serialization.Deserializer;
+import org.apache.kafka.common.serialization.Serializer;
 
 public interface Kafka<K, V> {
   default Producer<K, V> getProducer(Properties overrides) {
@@ -15,12 +17,16 @@ public interface Kafka<K, V> {
   
   Producer<K, V> getProducer(Properties defaults, Properties overrides);
   
+  Producer<K, V> getProducer(Properties overrides, Serializer<K> keySerializer, Serializer<V> valueSerializer);
+
   void describeProducer(LogLine logLine, Properties defaults, Properties overrides);
   
   default Consumer<K, V> getConsumer(Properties overrides) {
     return getConsumer(new Properties(), overrides);
   }
   
+  Consumer<K, V> getConsumer(Properties overrides, Deserializer<K> keyDeserializer, Deserializer<V> valueDeserializer);
+
   Consumer<K, V> getConsumer(Properties defaults, Properties overrides);
   
   void describeConsumer(LogLine logLine, Properties defaults, Properties overrides);

--- a/src/main/java/com/obsidiandynamics/jackdaw/KafkaCluster.java
+++ b/src/main/java/com/obsidiandynamics/jackdaw/KafkaCluster.java
@@ -12,6 +12,8 @@ import org.apache.kafka.clients.producer.*;
 import com.obsidiandynamics.func.*;
 import com.obsidiandynamics.props.*;
 import com.obsidiandynamics.yconf.*;
+import org.apache.kafka.common.serialization.Deserializer;
+import org.apache.kafka.common.serialization.Serializer;
 
 @Y
 public final class KafkaCluster<K, V> implements Kafka<K, V> {
@@ -40,6 +42,14 @@ public final class KafkaCluster<K, V> implements Kafka<K, V> {
   }
 
   @Override
+  public Producer<K, V> getProducer(Properties overrides, Serializer<K> keySerializer, Serializer<V> valueSerializer) {
+    mustExist(overrides, "Overrides cannot be null");
+    mustExist(keySerializer, "keySerializer cannot be null");
+    mustExist(valueSerializer, "valueSerializer cannot be null");
+    return new KafkaProducer<>(mergeProducerProps(new Properties(), overrides), keySerializer, valueSerializer);
+  }
+
+  @Override
   public void describeProducer(LogLine logLine, Properties defaults, Properties overrides) {
     mustExist(logLine, "Log line cannot be null");
     mustExist(defaults, "Defaults cannot be null");
@@ -50,6 +60,15 @@ public final class KafkaCluster<K, V> implements Kafka<K, V> {
                            s -> (overrides.containsKey(s) ? "* " : "- ") + rightPad(25).apply(s),
                            prefix(" "), 
                            any());
+  }
+
+  @Override
+  public Consumer<K, V> getConsumer(Properties overrides, Deserializer<K> keyDeserializer,
+                                    Deserializer<V> valueDeserializer) {
+    mustExist(overrides, "Overrides cannot be null");
+    mustExist(keyDeserializer, "keyDeserializer cannot be null");
+    mustExist(valueDeserializer, "valueDeserializer cannot be null");
+    return new KafkaConsumer<>(mergeConsumerProps(new Properties(), overrides), keyDeserializer, valueDeserializer);
   }
 
   private Properties mergeConsumerProps(Properties defaults, Properties overrides) {


### PR DESCRIPTION
Hi, I have added the following fix and feature:
- Fix: Use full constructor for building ConsumerRecord from ProducerRecord in order to also copy headers from producer.
- Feat: Add overload for getConsumer and getProducer including existing objects of serializers (Some serializers need extra information only available in running time) 