### PR TITLE
Adding ProducerRecord to ConsumerRecord mapper to MockKafka builder

### DIFF
--- a/assurance/src/main/java/com/obsidiandynamics/jackdaw/MockKafka.java
+++ b/assurance/src/main/java/com/obsidiandynamics/jackdaw/MockKafka.java
@@ -17,10 +17,12 @@ import com.obsidiandynamics.props.*;
 import com.obsidiandynamics.yconf.*;
 import com.obsidiandynamics.zerolog.*;
 import org.apache.kafka.common.header.Headers;
+import org.apache.kafka.common.header.internals.RecordHeaders;
 import org.apache.kafka.common.record.TimestampType;
 
 @Y
 public final class MockKafka<K, V> implements Kafka<K, V> {
+  public static final RecordHeaders EMPTY_RECORD_HEADERS = new RecordHeaders(Collections.emptyList());
   private final Zlg zlg = Zlg.forDeclaringClass().get();
   
   private final int maxPartitions;
@@ -148,15 +150,9 @@ public final class MockKafka<K, V> implements Kafka<K, V> {
 
   ConsumerRecord<K, V> defaultRecordMapping(ProducerRecord<K, V> record, RecordMetadata metadata) {
     final int partition = record.partition() != null ? record.partition() : metadata.partition();
-
-    // headers are optional but not-nullable in ConsumerRecord constructor
-    final Headers headers = record.headers();
-    if (null == headers) {
-        return new ConsumerRecord<>(record.topic(), partition, metadata.offset(), record.key(), record.value());
-    }
     return new ConsumerRecord<>(record.topic(), partition, metadata.offset(), metadata.timestamp(),
             TimestampType.NO_TIMESTAMP_TYPE, -1L, -1, -1,
-            record.key(), record.value(), headers);
+            record.key(), record.value(), record.headers());
   }
 
   static final class InvalidPartitionException extends IllegalArgumentException {

--- a/assurance/src/main/java/com/obsidiandynamics/jackdaw/MockKafka.java
+++ b/assurance/src/main/java/com/obsidiandynamics/jackdaw/MockKafka.java
@@ -22,7 +22,6 @@ import org.apache.kafka.common.record.TimestampType;
 
 @Y
 public final class MockKafka<K, V> implements Kafka<K, V> {
-  public static final RecordHeaders EMPTY_RECORD_HEADERS = new RecordHeaders(Collections.emptyList());
   private final Zlg zlg = Zlg.forDeclaringClass().get();
   
   private final int maxPartitions;

--- a/assurance/src/main/java/com/obsidiandynamics/jackdaw/MockKafka.java
+++ b/assurance/src/main/java/com/obsidiandynamics/jackdaw/MockKafka.java
@@ -116,7 +116,7 @@ public final class MockKafka<K, V> implements Kafka<K, V> {
             } else {
               final Future<RecordMetadata> f = super.send(r, (metadata, exception) -> {
                 if (callback != null) callback.onCompletion(metadata, exception);
-                ConsumerRecord<K, V> consumerRecord = recordMapper.apply(r, metadata);
+                final ConsumerRecord<K, V> consumerRecord = recordMapper.apply(r, metadata);
                 enqueue(consumerRecord);
               });
               return f;

--- a/assurance/src/main/java/com/obsidiandynamics/jackdaw/MockKafka.java
+++ b/assurance/src/main/java/com/obsidiandynamics/jackdaw/MockKafka.java
@@ -116,7 +116,7 @@ public final class MockKafka<K, V> implements Kafka<K, V> {
             } else {
               final Future<RecordMetadata> f = super.send(r, (metadata, exception) -> {
                 if (callback != null) callback.onCompletion(metadata, exception);
-                final ConsumerRecord<K, V> consumerRecord = recordMapper.apply(r, metadata);
+                ConsumerRecord<K, V> consumerRecord = recordMapper.apply(r, metadata);
                 enqueue(consumerRecord);
               });
               return f;

--- a/assurance/src/main/java/com/obsidiandynamics/jackdaw/MockKafka.java
+++ b/assurance/src/main/java/com/obsidiandynamics/jackdaw/MockKafka.java
@@ -20,42 +20,44 @@ import com.obsidiandynamics.zerolog.*;
 @Y
 public final class MockKafka<K, V> implements Kafka<K, V> {
   private final Zlg zlg = Zlg.forDeclaringClass().get();
-  
+
   private final int maxPartitions;
-  
+
   private final int maxHistory;
-  
+
   private FallibleMockProducer<K, V> producer;
-  
+
   private final List<FallibleMockConsumer<K, V>> consumers = new CopyOnWriteArrayList<>();
-  
+
   private List<ConsumerRecord<K, V>> backlog = new CopyOnWriteArrayList<>();
-  
+
   private final Object lock = new Object();
-  
+
   /** Tracks presence of group members. */
   private final Set<String> groups = new CopyOnWriteArraySet<>();
-  
+
   private ExceptionGenerator<ProducerRecord<K, V>, Exception> sendCallbackExceptionGenerator = ExceptionGenerator.never();
   private ExceptionGenerator<ProducerRecord<K, V>, RuntimeException> sendRuntimeExceptionGenerator = ExceptionGenerator.never();
   private ExceptionGenerator<Map<TopicPartition, OffsetAndMetadata>, Exception> commitExceptionGenerator = ExceptionGenerator.never();
-  
+
   private Supplier<AdminClient> adminClientFactory = PassiveAdminClient::getInstance;
-  
+  private BiFunction<ProducerRecord<K, V>, RecordMetadata, ConsumerRecord<K, V>> recordMapper;
+
   public MockKafka() {
     this(10, 100_000);
   }
-  
+
   public MockKafka(int maxPartitions, int maxHistory) {
     this.maxPartitions = maxPartitions;
     this.maxHistory = maxHistory;
+    this.recordMapper = this::defaultRecordMapping;
   }
-  
+
   public MockKafka<K, V> withSendCallbackExceptionGenerator(ExceptionGenerator<ProducerRecord<K, V>, Exception> sendCallbackExceptionGenerator) {
     this.sendCallbackExceptionGenerator = sendCallbackExceptionGenerator;
     return this;
   }
-  
+
   public MockKafka<K, V> withSendRuntimeExceptionGenerator(ExceptionGenerator<ProducerRecord<K, V>, RuntimeException> sendRuntimeExceptionGenerator) {
     this.sendRuntimeExceptionGenerator = sendRuntimeExceptionGenerator;
     return this;
@@ -65,9 +67,14 @@ public final class MockKafka<K, V> implements Kafka<K, V> {
     this.commitExceptionGenerator = commitExceptionGenerator;
     return this;
   }
-  
+
   public MockKafka<K, V> withAdminClientFactory(Supplier<AdminClient> adminClientFactory) {
     this.adminClientFactory = adminClientFactory;
+    return this;
+  }
+
+  public MockKafka<K, V> withRecordMapper(BiFunction<ProducerRecord<K, V>, RecordMetadata, ConsumerRecord<K, V>> recordMapper) {
+    this.recordMapper = recordMapper;
     return this;
   }
 
@@ -75,7 +82,7 @@ public final class MockKafka<K, V> implements Kafka<K, V> {
   public void describeProducer(LogLine logLine, Properties defaults, Properties overrides) {
     logLine.println("Mock producer");
   }
-  
+
   @Override
   public FallibleMockProducer<K, V> getProducer(Properties overrides) {
     return getProducer(new Properties(), overrides);
@@ -93,13 +100,13 @@ public final class MockKafka<K, V> implements Kafka<K, V> {
             this.sendCallbackExceptionGenerator = MockKafka.this.sendCallbackExceptionGenerator;
             this.sendRuntimeExceptionGenerator = MockKafka.this.sendRuntimeExceptionGenerator;
           }
-          
-          @Override 
+
+          @Override
           public Future<RecordMetadata> send(ProducerRecord<K, V> r, Callback callback) { // lgtm [java/non-sync-override]
             if (closed.get()) throw new IllegalStateException("Cannot send over a closed producer");
             final RuntimeException generatedRuntime = sendRuntimeExceptionGenerator.inspect(r);
             if (generatedRuntime != null) throw generatedRuntime;
-            
+
             final Exception generatedCallback = sendCallbackExceptionGenerator.inspect(r);
             if (generatedCallback != null) {
               if (callback != null) callback.onCompletion(null, generatedCallback);
@@ -109,16 +116,16 @@ public final class MockKafka<K, V> implements Kafka<K, V> {
             } else {
               final Future<RecordMetadata> f = super.send(r, (metadata, exception) -> {
                 if (callback != null) callback.onCompletion(metadata, exception);
-                final int partition = r.partition() != null ? r.partition() : metadata.partition();
-                enqueue(r, partition, metadata.offset());
+                ConsumerRecord<K, V> consumerRecord = recordMapper.apply(r, metadata);
+                enqueue(consumerRecord);
               });
               return f;
             }
           }
-          
+
           final AtomicBoolean closed = new AtomicBoolean();
-          
-          @Override 
+
+          @Override
           public void close(Duration duration) {
             if (closed.compareAndSet(false, true)) {
               super.close();
@@ -129,23 +136,26 @@ public final class MockKafka<K, V> implements Kafka<K, V> {
     }
     return producer;
   }
-  
+
+  private ConsumerRecord<K, V> defaultRecordMapping(ProducerRecord<K, V> record, RecordMetadata metadata) {
+    final int partition = record.partition() != null ? record.partition() : metadata.partition();
+    return new ConsumerRecord<>(record.topic(), partition, metadata.offset(), record.key(), record.value());
+  }
+
   static final class InvalidPartitionException extends IllegalArgumentException {
     private static final long serialVersionUID = 1L;
     InvalidPartitionException(String m) { super(m); }
   }
-  
-  private void enqueue(ProducerRecord<K, V> r, int partition, long offset) {
+
+  private void enqueue(ConsumerRecord<K, V> cr) {
+    int partition = cr.partition();
     if (partition >= maxPartitions) {
       final String m = String.format("Cannot send message on partition %d, "
           + "a maximum of %d partitions are supported", partition, maxPartitions);
       throw new InvalidPartitionException(m);
     }
-    
-    final ConsumerRecord<K, V> cr = 
-        new ConsumerRecord<>(r.topic(), partition, offset, r.key(), r.value());
-    
-    final TopicPartition part = new TopicPartition(r.topic(), partition);
+
+    final TopicPartition part = new TopicPartition(cr.topic(), partition);
     synchronized (lock) {
       backlog.add(cr);
       for (FallibleMockConsumer<K, V> consumer : consumers) {
@@ -157,14 +167,14 @@ public final class MockKafka<K, V> implements Kafka<K, V> {
           }
         }
       }
-      
+
       if (producer.history().size() > maxHistory) {
         producer.clear();
         backlog = backlog.subList(backlog.size() - maxHistory, backlog.size());
       }
     }
   }
-  
+
   public List<ConsumerRecord<K, V>> getBacklog() {
     synchronized (lock) {
       return Collections.unmodifiableList(new ArrayList<>(backlog));
@@ -175,7 +185,7 @@ public final class MockKafka<K, V> implements Kafka<K, V> {
   public void describeConsumer(LogLine logLine, Properties defaults, Properties overrides) {
     logLine.accept("Mock consumer");
   }
-  
+
   @Override
   public FallibleMockConsumer<K, V> getConsumer(Properties overrides) {
     return getConsumer(new Properties(), overrides);
@@ -192,17 +202,17 @@ public final class MockKafka<K, V> implements Kafka<K, V> {
       return createDetachedConsumer();
     }
   }
-  
+
   private FallibleMockConsumer<K, V> createAttachedConsumer() {
     return createConsumer(true);
   }
-  
+
   private FallibleMockConsumer<K, V> createDetachedConsumer() {
     return createConsumer(false);
   }
-  
+
   private static final int MIN_POLL_WAIT = 1_000;
-  
+
   private FallibleMockConsumer<K, V> createConsumer(boolean attached) {
     final Object lock;
     final List<FallibleMockConsumer<K, V>> consumers;
@@ -213,13 +223,13 @@ public final class MockKafka<K, V> implements Kafka<K, V> {
       lock = new Object();
       consumers = new ArrayList<>(1);
     }
-    
+
     final FallibleMockConsumer<K, V> consumer = new FallibleMockConsumer<K, V>(OffsetResetStrategy.EARLIEST) {
       {
         this.commitExceptionGenerator = MockKafka.this.commitExceptionGenerator;
       }
-      
-      @Override 
+
+      @Override
       public void commitAsync(Map<TopicPartition, OffsetAndMetadata> offsets, OffsetCommitCallback callback) { // lgtm [java/non-sync-override]
         final Exception generated = commitExceptionGenerator.inspect(offsets);
         if (generated != null) {
@@ -228,8 +238,8 @@ public final class MockKafka<K, V> implements Kafka<K, V> {
           super.commitAsync(offsets, callback);
         }
       }
-      
-      @Override 
+
+      @Override
       public void subscribe(Collection<String> topics, ConsumerRebalanceListener rebalanceListener) { // lgtm [java/non-sync-override]
         if (attached) {
           rebalanceListener.onPartitionsRevoked(Collections.emptySet());
@@ -240,12 +250,12 @@ public final class MockKafka<K, V> implements Kafka<K, V> {
               final List<TopicPartition> partitions = new ArrayList<>(maxPartitions);
               final Map<TopicPartition, Long> offsetRecords = new HashMap<>(maxPartitions, 1f);
               final List<ConsumerRecord<K, V>> records = new ArrayList<>();
-              
+
               for (int partIdx = 0; partIdx < maxPartitions; partIdx++) {
                 final TopicPartition part = new TopicPartition(topic, partIdx);
                 partitions.add(part);
                 offsetRecords.put(part, 0L);
-                
+
                 for (ConsumerRecord<K, V> cr : backlog) {
                   if (cr.topic().equals(topic) && cr.partition() == partIdx) {
                     records.add(cr);
@@ -253,7 +263,7 @@ public final class MockKafka<K, V> implements Kafka<K, V> {
                 }
               }
               subscribedPartitions.addAll(partitions);
-  
+
               assign(partitions);
               updateBeginningOffsets(offsetRecords);
               for (ConsumerRecord<K, V> cr : records) {
@@ -264,35 +274,35 @@ public final class MockKafka<K, V> implements Kafka<K, V> {
           rebalanceListener.onPartitionsAssigned(subscribedPartitions);
         }
       }
-      
-      @Override 
+
+      @Override
       public void subscribe(Collection<String> topics) { // lgtm [java/non-sync-override]
         subscribe(topics, new NoOpConsumerRebalanceListener());
       }
-      
-      @Override 
+
+      @Override
       public List<PartitionInfo> partitionsFor(String topic) { // lgtm [java/non-sync-override]
         final List<PartitionInfo> newInfos = new ArrayList<>(maxPartitions);
         final Map<TopicPartition, Long> offsets = new HashMap<>(maxPartitions, 1f);
-        
+
         for (int i = 0; i < maxPartitions; i++) {
           newInfos.add(new PartitionInfo(topic, i, null, new Node[0], new Node[0]));
           offsets.put(new TopicPartition(topic, i), 0L);
         }
-        
+
         synchronized (lock) {
           updateBeginningOffsets(offsets);
           updateEndOffsets(offsets);
         }
         return newInfos;
       }
-      
-      @Override 
+
+      @Override
       public ConsumerRecords<K, V> poll(Duration timeout) { // lgtm [java/non-sync-override]
         final long timeoutMillis = timeout.toMillis();
         // super.poll() disregards the timeout, resulting in a spin loop in the absence of records
         // and resource exhaustion on single-CPU machines
-        
+
         final long endTime = System.currentTimeMillis() + timeoutMillis;
         for (;;) {
           final ConsumerRecords<K, V> recs = super.poll(timeout);
@@ -319,8 +329,8 @@ public final class MockKafka<K, V> implements Kafka<K, V> {
           }
         }
       }
-      
-      @Override 
+
+      @Override
       public void close() { // lgtm [java/non-sync-override]
         synchronized (lock) {
           consumers.remove(this);
@@ -328,7 +338,7 @@ public final class MockKafka<K, V> implements Kafka<K, V> {
         super.close();
       }
     };
-    
+
     synchronized (lock) {
       consumers.add(consumer);
     }
@@ -339,7 +349,7 @@ public final class MockKafka<K, V> implements Kafka<K, V> {
   public AdminClient getAdminClient() {
     return adminClientFactory.get();
   }
-  
+
   private static <T> T instantiate(String className) {
     return Exceptions.wrap(() -> Classes.cast(Class.forName(className).getDeclaredConstructor().newInstance()),
                            RuntimeException::new);

--- a/assurance/src/test/java/com/obsidiandynamics/jackdaw/MockKafkaTest.java
+++ b/assurance/src/test/java/com/obsidiandynamics/jackdaw/MockKafkaTest.java
@@ -78,11 +78,27 @@ public final class MockKafkaTest {
   @Test
   public void testDefaultRecordMapping() {
     final MockKafka<Object, Object> mockKafka = new MockKafka<>();
-    // Null headers covered in other tests that don't specify any
     final RecordHeaders recordHeaders = new RecordHeaders(Collections.singleton(
                     new RecordHeader("headerKey", "headerValue".getBytes(StandardCharsets.UTF_8))));
+    final RecordMetadata recordMetadata = new RecordMetadata(new TopicPartition("topic", 0),
+            0, 0, 0, -1L, -1, -1);
     final ProducerRecord<Object, Object> producerRecord =
             new ProducerRecord<>("topic", 0, "key", "value", recordHeaders);
+
+    final ConsumerRecord<Object, Object> consumerRecord = mockKafka.defaultRecordMapping(producerRecord, recordMetadata);
+
+    assertEquals(producerRecord.topic(), consumerRecord.topic());
+    assertEquals(producerRecord.partition().intValue(), consumerRecord.partition());
+    assertEquals(producerRecord.key(), consumerRecord.key());
+    assertEquals(producerRecord.value(), consumerRecord.value());
+    assertEquals(producerRecord.headers(), consumerRecord.headers());
+  }
+
+  @Test
+  public void testDefaultRecordMappingNoHeaders() {
+    final MockKafka<Object, Object> mockKafka = new MockKafka<>();
+    final ProducerRecord<Object, Object> producerRecord =
+            new ProducerRecord<>("topic", 0, "key", "value");
     final RecordMetadata recordMetadata = new RecordMetadata(new TopicPartition("topic", 0),
             0, 0, 0, -1L, -1, -1);
 
@@ -92,7 +108,7 @@ public final class MockKafkaTest {
     assertEquals(producerRecord.partition().intValue(), consumerRecord.partition());
     assertEquals(producerRecord.key(), consumerRecord.key());
     assertEquals(producerRecord.value(), consumerRecord.value());
-    assertEquals(producerRecord.headers(), consumerRecord.headers());
+    assertEquals(new RecordHeaders(Collections.emptyList()), consumerRecord.headers());
   }
 
   private static final class TestConsumer<K, V> implements Terminable {

--- a/assurance/src/test/java/com/obsidiandynamics/jackdaw/MockKafkaTest.java
+++ b/assurance/src/test/java/com/obsidiandynamics/jackdaw/MockKafkaTest.java
@@ -94,23 +94,6 @@ public final class MockKafkaTest {
     assertEquals(producerRecord.headers(), consumerRecord.headers());
   }
 
-  @Test
-  public void testDefaultRecordMappingNoHeaders() {
-    final MockKafka<Object, Object> mockKafka = new MockKafka<>();
-    final ProducerRecord<Object, Object> producerRecord =
-            new ProducerRecord<>("topic", 0, "key", "value");
-    final RecordMetadata recordMetadata = new RecordMetadata(new TopicPartition("topic", 0),
-            0, 0, 0, -1L, -1, -1);
-
-    final ConsumerRecord<Object, Object> consumerRecord = mockKafka.defaultRecordMapping(producerRecord, recordMetadata);
-
-    assertEquals(producerRecord.topic(), consumerRecord.topic());
-    assertEquals(producerRecord.partition().intValue(), consumerRecord.partition());
-    assertEquals(producerRecord.key(), consumerRecord.key());
-    assertEquals(producerRecord.value(), consumerRecord.value());
-    assertEquals(new RecordHeaders(Collections.emptyList()), consumerRecord.headers());
-  }
-
   private static final class TestConsumer<K, V> implements Terminable {
     private final Kafka<K, V> kafka;
 

--- a/assurance/src/test/java/com/obsidiandynamics/jackdaw/MockKafkaTest.java
+++ b/assurance/src/test/java/com/obsidiandynamics/jackdaw/MockKafkaTest.java
@@ -30,39 +30,58 @@ import com.obsidiandynamics.worker.*;
 import com.obsidiandynamics.worker.Terminator;
 
 @RunWith(Parameterized.class)
-public final class MockKafkaTest {  
+public final class MockKafkaTest {
   @Parameterized.Parameters
   public static List<Object[]> data() {
     return TestCycle.timesQuietly(1);
   }
-  
+
   private static final String TOPIC = "test";
-  
+
   private final Timesert wait = Timesert.wait(10_000);
-  
+
   private final List<Terminable> terminables = new ArrayList<>();
-  
+
   @After
   public void after() {
     Terminator.of(terminables).terminate().joinSilently();
     terminables.clear();
   }
-  
+
   @Test
   public void testProduceConsume() throws InterruptedException {
     testProduceConsume(10, 3, 0, 5);
   }
-  
+
+  @Test
+  public void testWithRecordMapper() {
+    ConsumerRecord<Object, Object> expectedRecord =
+            new ConsumerRecord<>("topic", 0, 0, "key", "value");
+    Kafka<Object, Object> mockKafka = new MockKafka<>()
+            .withRecordMapper((objectObjectProducerRecord, recordMetadata) -> expectedRecord);
+    final SerdeProps props = new SerdeProps(SerdePair.STRING);
+    final Producer<Object, Object> producer = mockKafka.getProducer(props.producer());
+    Consumer<Object, Object> consumer = mockKafka.getConsumer(new Properties());
+    consumer.subscribe(Collections.singleton("topic"));
+    producer.send(new ProducerRecord<>("topic", 0, "key", "value"));
+
+    wait.until(() -> {
+      ConsumerRecords<Object, Object> consumerRecords = consumer.poll(Duration.ofMillis(1));
+      assertEquals(1, consumerRecords.count());
+      assertSame(expectedRecord, consumerRecords.iterator().next());
+    });
+  }
+
   private static final class TestConsumer<K, V> implements Terminable {
     private final Kafka<K, V> kafka;
-    
+
     private final WorkerThread thread;
-    
-    private Consumer<K, V> consumer; 
-    
-    final KeyedBlockingQueue<Integer, ConsumerRecord<K, V>> received = 
+
+    private Consumer<K, V> consumer;
+
+    final KeyedBlockingQueue<Integer, ConsumerRecord<K, V>> received =
         new KeyedBlockingQueue<>(LinkedBlockingQueue::new);
-    
+
     TestConsumer(Kafka<K, V> kafka) {
       this.kafka = kafka;
       thread = WorkerThread.builder()
@@ -72,21 +91,21 @@ public final class MockKafkaTest {
           .onShutdown(this::shutdown)
           .buildAndStart();
     }
-    
+
     private void startup(WorkerThread t) {
       consumer = kafka.getConsumer(new Properties());
       consumer.subscribe(Arrays.asList(TOPIC));
     }
-    
+
     private void run(WorkerThread t) {
       final ConsumerRecords<K, V> records = consumer.poll(Duration.ofMillis(1));
       records.forEach(r -> received.forKey(r.partition()).add(r));
     }
-    
+
     private void shutdown(WorkerThread t, Throwable exception) {
       consumer.close();
     }
-    
+
     @Override
     public Joinable terminate() {
       return thread.terminate();
@@ -109,7 +128,7 @@ public final class MockKafkaTest {
       if (consumers.size() < numConsumers) {
         consumers.add(new TestConsumer<>(kafka));
       }
-      
+
       if (m != messages - 1 && sendIntervalMillis != 0) {
         Threads.sleep(sendIntervalMillis);
       }
@@ -117,12 +136,12 @@ public final class MockKafkaTest {
 
     final int expectedMessages = messages * partitions;
     assertEquals(expectedMessages, sent.get());
-    
+
     while (consumers.size() < numConsumers) {
       consumers.add(new TestConsumer<>(kafka));
     }
     terminables.addAll(consumers);
-    
+
     try {
       wait.untilTrue(() -> consumers.stream().filter(c -> c.received.totalSize() < expectedMessages).count() == 0);
     } finally {
@@ -140,35 +159,35 @@ public final class MockKafkaTest {
         }
       }
     }
-    
+
     assertTrue("history.size=" + producer.history().size(), producer.history().size() <= maxHistory);
-    
+
     producer.close();
   }
-  
+
   @Test
   public void testSingletonProducer() {
     final MockKafka<String, String> kafka = new MockKafka<>(1, 1);
     final SerdeProps props = new SerdeProps(SerdePair.STRING);
-    
+
     final Producer<String, String> p0 = kafka.getProducer(props.producer());
     assertNotNull(p0);
-    
+
     final Producer<String, String> p1 = kafka.getProducer(props.producer());
     assertSame(p0, p1);
   }
-  
+
   private static class TestRuntimeException extends RuntimeException {
     private static final long serialVersionUID = 1L;
   }
-  
+
   @Test
   public void testDescribeProducer() {
     final LogLine logLine = mock(LogLine.class, Answers.CALLS_REAL_METHODS);
     new MockKafka<String, String>(1, 1).describeProducer(logLine, new Properties(), new Properties());
     verify(logLine).accept(notNull());
   }
-  
+
   @Test(expected=TestRuntimeException.class)
   public void testSendWithRuntimeError() {
     final TestRuntimeException cause = new TestRuntimeException();
@@ -178,7 +197,7 @@ public final class MockKafkaTest {
     final Producer<String, String> producer = kafka.getProducer(props.producer());
     producer.send(new ProducerRecord<>("topic", "value"));
   }
-  
+
   @Test
   public void testSendWithCallbackError() throws InterruptedException {
     final Exception cause = new Exception("simulated");
@@ -195,10 +214,10 @@ public final class MockKafkaTest {
     } catch (ExecutionException e) {
       assertEquals(cause, e.getCause());
     }
-    
+
     verify(callback).onCompletion(any(), eq(cause));
   }
-  
+
   @Test
   public void testSendWithCallbackErrorWithoutCallback() throws InterruptedException {
     final Exception cause = new Exception("simulated");
@@ -215,7 +234,7 @@ public final class MockKafkaTest {
       assertEquals(cause, e.getCause());
     }
   }
-  
+
   @Test(expected=IllegalStateException.class)
   public void testSend_closedProducer() {
     final TestRuntimeException cause = new TestRuntimeException();
@@ -226,7 +245,7 @@ public final class MockKafkaTest {
     producer.close();
     producer.send(new ProducerRecord<>("topic", "value"));
   }
-  
+
   @Test(expected=InvalidPartitionException.class)
   public void testSend_invalidPartition() {
     final MockKafka<String, String> kafka = new MockKafka<>(1, 1);
@@ -234,7 +253,7 @@ public final class MockKafkaTest {
     final Producer<String, String> producer = kafka.getProducer(props.producer());
     producer.send(new ProducerRecord<>("topic", 1, "key", "value"));
   }
-  
+
   @Test
   public void testSend_clearBacklog() {
     final int maxHistory = 1;
@@ -246,9 +265,9 @@ public final class MockKafkaTest {
     }
     assertEquals(maxHistory, kafka.getBacklog().size());
   }
-  
+
   /**
-   *  Tests attached/detached consumers in a group; we should be able receive on 
+   *  Tests attached/detached consumers in a group; we should be able receive on
    *  an attached consumer (the first one), but not a detached one (all others).
    */
   @Test
@@ -256,24 +275,24 @@ public final class MockKafkaTest {
     final MockKafka<String, String> kafka = new MockKafka<>(1, 1);
     final SerdeProps props = new SerdeProps(SerdePair.STRING);
     final Producer<String, String> producer = kafka.getProducer(props.producer());
-    
+
     final Properties consumerProps = new Properties();
     consumerProps.putAll(props.consumer());
     consumerProps.put("group.id", "group");
-    
+
     final Consumer<String, String> attached = kafka.getConsumer(consumerProps);
     attached.subscribe(Arrays.asList("topic"), new NoOpConsumerRebalanceListener());
-    
+
     final Consumer<String, String> detached = kafka.getConsumer(consumerProps);
     detached.subscribe(Arrays.asList("topic"));
-    
+
     producer.send(new ProducerRecord<>("topic", 0, "key", "value"));
     wait.until(() -> assertEquals(1, attached.poll(Duration.ofMillis(1)).count()));
-    
+
     Threads.sleep(10);
     assertEquals(0, detached.poll(Duration.ofMillis(1)).count());
   }
-  
+
   /**
    *  Tests that a consumer subscribing twice to the same topic doesn't result in
    *  message duplication.
@@ -283,11 +302,11 @@ public final class MockKafkaTest {
     final MockKafka<String, String> kafka = new MockKafka<>(2, 1);
     final SerdeProps props = new SerdeProps(SerdePair.STRING);
     final Producer<String, String> producer = kafka.getProducer(props.producer());
-    
+
     final Consumer<String, String> attached = kafka.getConsumer(props.consumer());
     attached.subscribe(Arrays.asList("topic"));
     attached.subscribe(Arrays.asList("topic"));
-    
+
     producer.send(new ProducerRecord<>("topic", 0, "key", "value"));
     wait.until(() -> assertEquals(1, attached.poll(Duration.ofMillis(1)).count()));
   }
@@ -302,8 +321,8 @@ public final class MockKafkaTest {
     final MockKafka<String, String> kafka = new MockKafka<>(2, 1);
     final SerdeProps props = new SerdeProps(SerdePair.STRING);
     final Producer<String, String> producer = kafka.getProducer(props.producer());
-    
-    
+
+
     final Consumer<String, String> consumer = kafka.getConsumer(props.consumer());
     consumer.subscribe(Arrays.asList("different"));
     producer.send(new ProducerRecord<>("topic", 0, "key", "value"));
@@ -317,8 +336,8 @@ public final class MockKafkaTest {
   public void testConsumeInterrupted() {
     final MockKafka<String, String> kafka = new MockKafka<>(2, 1);
     final SerdeProps props = new SerdeProps(SerdePair.STRING);
-    
-    
+
+
     final Consumer<String, String> consumer = kafka.getConsumer(props.consumer());
     consumer.subscribe(Arrays.asList("different"));
     Thread.currentThread().interrupt();
@@ -339,9 +358,9 @@ public final class MockKafkaTest {
     final MockKafka<String, String> kafka = new MockKafka<>(2, 1);
     final SerdeProps props = new SerdeProps(SerdePair.STRING);
     final Producer<String, String> producer = kafka.getProducer(props.producer());
-    
+
     producer.send(new ProducerRecord<>("topic", 0, "key", "value"));
-    
+
     final Consumer<String, String> consumer = kafka.getConsumer(props.consumer());
     consumer.subscribe(Arrays.asList("different"));
     assertEquals(0, consumer.poll(Duration.ofMillis(1)).count());
@@ -351,10 +370,10 @@ public final class MockKafkaTest {
   public void testPartitionsFor_existingTopic() {
     final MockKafka<String, String> kafka = new MockKafka<>(1, 1);
     final SerdeProps props = new SerdeProps(SerdePair.STRING);
-    
+
     final Producer<String, String> producer = kafka.getProducer(props.producer());
     producer.send(new ProducerRecord<>("topic", 0, "key", "value"));
-    
+
     final Consumer<String, String> consumer = kafka.getConsumer(props.consumer());
     final List<PartitionInfo> partitions = consumer.partitionsFor("topic");
     assertEquals(1, partitions.size());
@@ -364,70 +383,70 @@ public final class MockKafkaTest {
   public void testPartitionsFor_nonExistentTopic() {
     final MockKafka<String, String> kafka = new MockKafka<>(1, 1);
     final SerdeProps props = new SerdeProps(SerdePair.STRING);
-    
+
     final Consumer<String, String> consumer = kafka.getConsumer(props.consumer());
     final List<PartitionInfo> partitions = consumer.partitionsFor("topic");
     assertEquals(1, partitions.size());
   }
-  
+
   @Test
   public void testCommitAsync() {
     final MockKafka<String, String> kafka = new MockKafka<>(1, 1);
     final SerdeProps props = new SerdeProps(SerdePair.STRING);
-    
+
     final Consumer<String, String> consumer = kafka.getConsumer(props.consumer());
     final Map<TopicPartition, OffsetAndMetadata> offsets = new HashMap<>();
     final OffsetCommitCallback callback = mock(OffsetCommitCallback.class);
     consumer.commitAsync(offsets, callback);
     wait.until(() -> verify(callback).onComplete(notNull(), isNull()));
   }
-  
+
   @Test
   public void testCommitAsync_withError() {
     final Exception cause = new Exception("simulated");
     final MockKafka<String, String> kafka = new MockKafka<String, String>(1, 1)
         .withCommitExceptionGenerator(__ -> cause);
     final SerdeProps props = new SerdeProps(SerdePair.STRING);
-    
+
     final Consumer<String, String> consumer = kafka.getConsumer(props.consumer());
     final Map<TopicPartition, OffsetAndMetadata> offsets = new HashMap<>();
     final OffsetCommitCallback callback = mock(OffsetCommitCallback.class);
     consumer.commitAsync(offsets, callback);
     wait.until(() -> verify(callback).onComplete(notNull(), eq(cause)));
   }
-  
+
   @Test
   public void testCommitAsync_withErrorNoCallback() {
     final Exception cause = new Exception("simulated");
     final MockKafka<String, String> kafka = new MockKafka<String, String>(1, 1)
         .withCommitExceptionGenerator(__ -> cause);
     final SerdeProps props = new SerdeProps(SerdePair.STRING);
-    
+
     final Consumer<String, String> consumer = kafka.getConsumer(props.consumer());
     final Map<TopicPartition, OffsetAndMetadata> offsets = new HashMap<>();
     consumer.commitAsync(offsets, null);
   }
-  
+
   @Test
   public void testDescribeConsumer() {
     final LogLine logLine = mock(LogLine.class, Answers.CALLS_REAL_METHODS);
     new MockKafka<String, String>(1, 1).describeConsumer(logLine, new Properties(), new Properties());
     verify(logLine).accept(notNull());
   }
-  
+
   @Test
   public void testGetAdminClient_defaultFactory() throws InterruptedException, ExecutionException {
     final AdminClient adminClient = new MockKafka<>().getAdminClient();
     assertSame(adminClient, PassiveAdminClient.getInstance());
   }
-  
+
   @Test
   public void testGetAdminClient_customFactory() {
     final AdminClient adminClient = mock(AdminClient.class);
     final MockKafka<?, ?> kafka = new MockKafka<>().withAdminClientFactory(() -> adminClient);
     assertSame(adminClient, kafka.getAdminClient());
   }
-  
+
   @Test
   public void testToString() {
     Assertions.assertToStringOverride(new MockKafka<>(1, 1));


### PR DESCRIPTION
The current implementation discards the record headers. The constructors for ConsumerRecord have some arguments that don't make sense for mocking, but I do need the headers. 

I thought it would be good to parameterize the mapping from ProducerRecord to ConsumerRecord, with the default being the current implementation.

(I'm not that experienced with Git and pull requests and had to clean up some accidental reformatting)

Example usage:

> 
        _kafkaFactory = new MockKafka<String, byte[]>()
                .withRecordMapper((inProducerRecord, inRecordMetadata) -> {
                    int partition = inProducerRecord.partition() != null ? inProducerRecord.partition() : inRecordMetadata.partition();
                    return new ConsumerRecord<String, byte[]>(inProducerRecord.topic(), partition, inRecordMetadata.offset(),
                            inRecordMetadata.timestamp(),
                            TimestampType.NO_TIMESTAMP_TYPE, -1L, -1, -1, inProducerRecord.key(),
                            inProducerRecord.value(), inProducerRecord.headers());
                });

 